### PR TITLE
Use fixed versions of the repositories, not the "latest"

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -144,19 +144,10 @@ eval $(opam env)
 
 opam_build ocamlgraph
 
-
-
 cd irmin
 git checkout 2.9.0
-opam install -y --deps-only .
-for i in $(seq 1 "$NB_RUNS"); do
-  rm -f build.log
-  dune clean
-  OCAMLPARAM=",_,timings=1" dune build --verbose --profile=release @install 2>&1 | tee -a build.log | sed 's/^{/ {/'
-  timings "irmin"
-done
 cd ..
-
+opam_build irmin
 
 cd opam
 opam install crowbar

--- a/bench.sh
+++ b/bench.sh
@@ -45,11 +45,21 @@ dune_build () {
   cd ..
 }
 
+opam_build() {
+  project=$1
+  target=${2:-.}
+  cd "$project"
+  opam pin -ny .
+  opam install -y -t --deps-only .
+  cd ..
+  dune_build "$project" "$target"
+}
+
 bootstrap () {
   for i in $(seq 1 "$NB_RUNS"); do
     rm -f build.log
     make clean
-          OCAMLPARAM=",_,timings=1" make world.opt | tee -a build.log | sed 's/^{/ {/'
+    OCAMLPARAM=",_,timings=1" make world.opt | tee -a build.log | sed 's/^{/ {/'
     timings 'ocaml'
   done
 }
@@ -130,17 +140,6 @@ opam install -y sexplib
 eval $(opam env)
 opam install -y git-unix git-paf
 eval $(opam env)
-
-
-opam_build() {
-  project=$1
-  target=${2:-.}
-  cd "$project"
-  opam pin -ny .
-  opam install -y -t --deps-only .
-  cd ..
-  dune_build "$project" "$target"
-}
 
 
 opam_build ocamlgraph

--- a/bench.sh
+++ b/bench.sh
@@ -29,8 +29,12 @@ timings () {
 
 dune_build () {
   project=$1
-  target=${2:-.}
+  version=$2
+  target=${3:-.}
   cd "$project"
+  if [ ! -z $version ]; then
+      git checkout $version
+  fi
   for i in $(seq 1 "$NB_RUNS"); do
     rm -f build.log
     dune clean
@@ -47,12 +51,16 @@ dune_build () {
 
 opam_build() {
   project=$1
-  target=${2:-.}
+  version=$2
+  target=${3:-.}
   cd "$project"
+  if [ ! -z $version ]; then
+      git checkout $version
+  fi
   opam pin -ny .
   opam install -y -t --deps-only .
   cd ..
-  dune_build "$project" "$target"
+  dune_build "$project" "$version" "$target"
 }
 
 bootstrap () {
@@ -142,12 +150,9 @@ opam install -y git-unix git-paf
 eval $(opam env)
 
 
-opam_build ocamlgraph
+opam_build ocamlgraph bd6c8ce2e64dee10e800aeda648684409cfa0bff
 
-cd irmin
-git checkout 2.9.0
-cd ..
-opam_build irmin
+opam_build irmin "2.9.0"
 
 cd opam
 opam install crowbar
@@ -161,13 +166,13 @@ for i in $(seq 1 "$NB_RUNS"); do
 done
 cd ..
 
-dune_build deque
+dune_build deque 20d3cfafa93b73c9f7ee20c230dc3e1b3f86956e
 
-opam_build ocaml-containers
+opam_build ocaml-containers 40189757cae1de9e43bf9c7ac92d7412868b2846
 
-opam_build decompress
+opam_build decompress 1871eea4d5a1e72116b4202c05a07bfb57965ad9
 
-opam_build menhir '--only-packages=menhir'
+opam_build menhir 7fdc5a97d2baa8ced49e07879e1841f1b13b4132 '--only-packages=menhir'
 
 # dune_build mirage
 

--- a/bench.sh
+++ b/bench.sh
@@ -152,7 +152,7 @@ eval $(opam env)
 
 opam_build ocamlgraph bd6c8ce2e64dee10e800aeda648684409cfa0bff
 
-opam_build irmin "2.9.0"
+opam_build irmin "3.0.0"
 
 cd opam
 opam install crowbar


### PR DESCRIPTION
> The bench.Dockerfile should use a fixed version of the repositories, not "the latest" as otherwise we don't know if regressions happened because of the PR or an update to the external repo.